### PR TITLE
Decouple/fix sorting logic

### DIFF
--- a/demos/src/thuja_demo.adb
+++ b/demos/src/thuja_demo.adb
@@ -14,6 +14,7 @@ with standardized_tab_interface;    -- Defines the abstract tab interface (commo
 with Thuja_demo_tab_htop;           -- Implementation of the HTop-style monitoring tab
 with Thuja_demo_tab_editor;         -- Implementation of the text editor tab
 with Thuja_demo_tab_flex;           -- Implementation of the flexbox demo tab
+with Thuja_demo_tab_sort;           -- Implementation of the sound of sorting demo tab
 
 procedure Thuja_Demo is
 
@@ -23,15 +24,17 @@ procedure Thuja_Demo is
    HTop_Tab    : aliased Thuja_demo_tab_htop.Tab_T;
    Editor_Tab  : aliased Thuja_demo_tab_editor.Tab_T;
    Flex_Tab    : aliased Thuja_demo_tab_flex.Tab_T;
+   Sort_Tab    : aliased Thuja_demo_tab_sort.Tab_T;
 
    -- Array of polymorphic tab pointers using the interface access type.
    -- Unchecked_Access is used to bypass Ada accessibility checks.
    -- Should be safe since all tab objects outlive the array usage.
-   type Tab_Array is array (0 .. 2) of standardized_tab_interface.Tab_Access;
+   type Tab_Array is array (0 .. 3) of standardized_tab_interface.Tab_Access;
    Tabs : constant Tab_Array :=
      [0 => HTop_Tab'Unchecked_Access,
       1 => Editor_Tab'Unchecked_Access,
-      2 => Flex_Tab'Unchecked_Access];
+      2 => Flex_Tab'Unchecked_Access,
+      3 => Sort_Tab'Unchecked_Access];
 
    -- Local type aliases for readability and consistency
    subtype String_t is String;

--- a/demos/src/thuja_demo_tab_sort.adb
+++ b/demos/src/thuja_demo_tab_sort.adb
@@ -1,0 +1,111 @@
+with Components; use Components;
+with IDs;        use IDs;
+with ECS;        use ECS;
+with Sort_Demo;
+
+package body Thuja_demo_tab_sort is
+
+   overriding
+   procedure Create_Entities
+     (Tab         : in out Tab_T;
+      World       : in out ECS.Entity_Components_PO;
+      Content_Top : in TUI_Height;
+      Term_Width  : in TUI_Width;
+      Term_Height : in TUI_Height)
+   is
+      CP  : Components_Ptr;
+      Page : Tab_Page_Component_T;
+   begin
+      Page.Tab_Index := 3;
+      Sort_Bar_H  := Term_Height - Content_Top - 1;
+      Sort_Code_H := Sort_Bar_H;
+      Sort_Stat_H := 2;
+
+      CP :=
+        Make_Widget
+          (World,
+           "sort_bars",
+           TUI_Width'First,
+           Content_Top,
+           TUI_Width (Sort_Demo.Bar_W),
+           Sort_Bar_H);
+      Add_Component (CP.all, To_CID ("TabPage"), Page);
+
+      CP :=
+        Make_Widget
+          (World,
+           "sort_code",
+           TUI_Width (Sort_Demo.Bar_W + 1),
+           Content_Top,
+           TUI_Width (Sort_Demo.Code_W),
+           Sort_Code_H);
+      Add_Component (CP.all, To_CID ("TabPage"), Page);
+
+      CP :=
+        Make_Widget
+          (World,
+           "sort_stat",
+           TUI_Width'First,
+           Term_Height - 1,
+           Term_Width,
+           Sort_Stat_H);
+      Add_Component (CP.all, To_CID ("TabPage"), Page);
+   end Create_Entities;
+
+   overriding
+   procedure Update
+     (Tab : in out Tab_T; World : in out ECS.Entity_Components_PO)
+   is
+      EL : Entity_Components_Ptr;
+      CP : Components_Ptr;
+   begin
+      Sort_Demo.Tick;
+
+      World.Claim_Writing (EL);
+
+      CP := Get_Entity_Components (EL.all, To_EID ("sort_bars"));
+      if CP /= null then
+         declare
+            W : Widget_Component_T :=
+              Widget_Component_T
+                (Get_Component (CP.all, To_CID ("WidgetComponent")));
+         begin
+            Sort_Demo.Render_Bars
+              (W.Render_Buffer,
+               TUI_Width (Sort_Demo.Bar_W),
+               Sort_Bar_H);
+            Add_Component (CP.all, To_CID ("WidgetComponent"), W);
+         end;
+      end if;
+
+      CP := Get_Entity_Components (EL.all, To_EID ("sort_code"));
+      if CP /= null then
+         declare
+            W : Widget_Component_T :=
+              Widget_Component_T
+                (Get_Component (CP.all, To_CID ("WidgetComponent")));
+         begin
+            Sort_Demo.Render_Code
+              (W.Render_Buffer,
+               TUI_Width (Sort_Demo.Code_W),
+               Sort_Code_H);
+            Add_Component (CP.all, To_CID ("WidgetComponent"), W);
+         end;
+      end if;
+
+      CP := Get_Entity_Components (EL.all, To_EID ("sort_stat"));
+      if CP /= null then
+         declare
+            W : Widget_Component_T :=
+              Widget_Component_T
+                (Get_Component (CP.all, To_CID ("WidgetComponent")));
+         begin
+            Sort_Demo.Render_Status (W.Render_Buffer, W.Size_Width, Sort_Stat_H);
+            Add_Component (CP.all, To_CID ("WidgetComponent"), W);
+         end;
+      end if;
+
+      World.Release_Writing;
+   end Update;
+
+end Thuja_demo_tab_sort;

--- a/demos/src/thuja_demo_tab_sort.ads
+++ b/demos/src/thuja_demo_tab_sort.ads
@@ -1,0 +1,25 @@
+with standardized_tab_interface;
+with ECS;
+with Graphics; use Graphics;
+
+package Thuja_demo_tab_sort is
+
+   type Tab_T is new standardized_tab_interface.Tab_T with null record;
+
+   Sort_Bar_H  : TUI_Height;
+   Sort_Code_H : TUI_Height;
+   Sort_Stat_H : TUI_Height;
+
+   overriding
+   procedure Create_Entities
+     (Tab         : in out Tab_T;
+      World       : in out ECS.Entity_Components_PO;
+      Content_Top : in TUI_Height;
+      Term_Width  : in TUI_Width;
+      Term_Height : in TUI_Height);
+
+   overriding
+   procedure Update
+     (Tab : in out Tab_T; World : in out ECS.Entity_Components_PO);
+
+end Thuja_demo_tab_sort;


### PR DESCRIPTION
Last PR was rebuilding incorrectly as object files (or something) were retained through alr clean and causing faulty source code to produce valid binaries.