### PR TITLE
Patch to fix text editor cutting into status bar when scrolling.

### DIFF
--- a/demos/src/thuja_demo.adb
+++ b/demos/src/thuja_demo.adb
@@ -18,8 +18,6 @@ with Thuja_demo_tab_sort;           -- Implementation of the sound of sorting de
 
 procedure Thuja_Demo is
 
-
-
    -- Concrete tab instances declared locally within the main procedure.
    HTop_Tab    : aliased Thuja_demo_tab_htop.Tab_T;
    Editor_Tab  : aliased Thuja_demo_tab_editor.Tab_T;

--- a/src/thuja_demo_tab_editor.adb
+++ b/src/thuja_demo_tab_editor.adb
@@ -24,7 +24,7 @@ package body Thuja_demo_tab_editor is
       Stat_BG : constant Color_t := Blue;
    begin
       Page.Tab_Index := 1;
-      Ed_H := Term_Height - Content_Top;
+      Ed_H := Term_Height - Content_Top - 1;
 
       CP :=
         Make_Widget_With_BG
@@ -50,7 +50,7 @@ package body Thuja_demo_tab_editor is
           (World,
            "ed_status",
            TUI_Width'First,
-           Term_Height,
+           Content_Top + Ed_H,
            Term_Width,
            1,
            Stat_BG);


### PR DESCRIPTION
Text editor was greedily taking all available rows including the status bar, fixed to prevent this from occurring.