### PR TITLE
Fix Ada language server by explicitly defining project file in workspace settings - for VSCODE environment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "sarif-viewer.connectToGithubCodeScanning": "off",
-    "editor.formatOnPaste": true
+    "editor.formatOnPaste": true,
+    "ada.projectFile": "demos/demos.gpr"
 }


### PR DESCRIPTION
This change resolves an issue where the Ada language server fails to initialize or find the correct project context in VS Code. It explicitly specifies the project file configuration inside the workspace settings. Without this change it gives 150+ false alarm errors in thuja_demo.