### PR TITLE
Linux arrow handling

### DIFF
--- a/demos/src/thuja_demo.adb
+++ b/demos/src/thuja_demo.adb
@@ -576,6 +576,18 @@ begin
                   when Tab    =>
                      Text_Editor.Handle_Tab;
 
+                  when Up     =>
+                     Text_Editor.Handle_Navigation (Character_t'('w'));
+
+                  when Left   =>
+                     Text_Editor.Handle_Navigation (Character_t'('a'));
+
+                  when Down   =>
+                     Text_Editor.Handle_Navigation (Character_t'('s'));
+
+                  when Right  =>
+                     Text_Editor.Handle_Navigation (Character_t'('d'));
+
                   when others =>
                      if Event.Char_Value = Character_t'Val (127)
                        or else Event.Char_Value = Character_t'Val (8)
@@ -590,6 +602,18 @@ begin
                   when Quit   =>
                      Running := False;
                      exit;
+
+                  when Up     =>
+                     Text_Editor.Handle_Navigation (Character_t'('w'));
+
+                  when Left   =>
+                     Text_Editor.Handle_Navigation (Character_t'('a'));
+
+                  when Down   =>
+                     Text_Editor.Handle_Navigation (Character_t'('s'));
+
+                  when Right  =>
+                     Text_Editor.Handle_Navigation (Character_t'('d'));
 
                   when others =>
                      Text_Editor.Handle_Navigation (Event.Char_Value);
@@ -657,7 +681,7 @@ begin
                      exit;
                   end if;
             end case;
-         
+
          elsif Get_Active_Tab (World) = 4 then
             if Event.Cmd = Quit or else Event.Char_Value = Character_t'Val (27)
             then

--- a/demos/src/thuja_demo_tab_keyboard.adb
+++ b/demos/src/thuja_demo_tab_keyboard.adb
@@ -55,6 +55,7 @@ package body Thuja_demo_tab_keyboard is
 
    --  Persistent tab state
    Pressed_Key      : Character_t         := Character_t'Val (0);
+   Pressed_Cmd      : Command_t           := None;
    Pending_Keys     : SU.Unbounded_String := SU.Null_Unbounded_String;
    Initialized      : Boolean             := False;
 
@@ -423,6 +424,9 @@ package body Thuja_demo_tab_keyboard is
          or Pressed_Key = Character_t'Val (127)
       then
          Set_Key_Color (Entity_List, "BKSP", Color_Pressed_Key);
+      elsif Pressed_Cmd = Up or Pressed_Cmd = Down or Pressed_Cmd = Right
+        or Pressed_Cmd = Left then
+         null;
       elsif Pressed_Key >= ' ' and Pressed_Key <= '~' then
          declare
             Lower : constant Character_t :=
@@ -540,7 +544,15 @@ package body Thuja_demo_tab_keyboard is
       Hex_Str   : constant String_t :=
         "0x" & Hex_Chars (Hi + 1) & Hex_Chars (Lo + 1);
    begin
-      if Pressed_Key >= ' ' and Pressed_Key <= '~' then
+      if Pressed_Cmd = Up then
+         Write ("Last key: UP  [" & Hex_Str & "]");
+      elsif Pressed_Cmd = Down then
+         Write ("Last key: DOWN  [" & Hex_Str & "]");
+      elsif Pressed_Cmd = Right then
+         Write ("Last key: RIGHT  [" & Hex_Str & "]");
+      elsif Pressed_Cmd = Left then
+         Write ("Last key: LEFT  [" & Hex_Str & "]");
+      elsif Pressed_Key >= ' ' and Pressed_Key <= '~' then
          Write ("Last key: '" & Pressed_Key & "'  [" & Hex_Str & "]");
       elsif Pressed_Key = Character_t'Val (9) then
          Write ("Last key: TAB  [0x09]");
@@ -1136,7 +1148,21 @@ package body Thuja_demo_tab_keyboard is
       end if;
 
       Last_Byte := Character_t'Pos (Event.Char_Value);
-      Cmd_Result := Command_Sequence_Handling.Process_Key (Event.Char_Value);
+      --  Inputs that should ignore command sequences
+      if Event.Cmd   = Up
+        or Event.Cmd = Down
+        or Event.Cmd = Right
+        or Event.Cmd = Left
+      then
+         --  Process a null character to clear the command sequence
+         Cmd_Result := Command_Sequence_Handling.Process_Key (Character_t'Val (0));
+         --  Produce result indicating passthrough
+         Cmd_Result := (Kind => Command_Sequence_Handling.Keys_Passed_Through,
+                        Keys => SU."&" (SU.Null_Unbounded_String, Event.Char_Value),
+                        Command_Index => <>);
+      else
+         Cmd_Result := Command_Sequence_Handling.Process_Key (Event.Char_Value);
+      end if;
 
       World.Claim_Writing (Entity_List);
 
@@ -1162,6 +1188,7 @@ package body Thuja_demo_tab_keyboard is
             if SU.Length (Cmd_Result.Keys) > 0 then
                Pressed_Key := SU.Element
                  (Cmd_Result.Keys, SU.Length (Cmd_Result.Keys));
+               Pressed_Cmd := Event.Cmd;
                Update_Key_Colors (Entity_List);
                Update_Ordinary_Status (Entity_List);
             end if;

--- a/src/input_handling.adb
+++ b/src/input_handling.adb
@@ -27,6 +27,23 @@ package body Input_Handling is
       return True;
    end Dequeue;
 
+   --  Remove and return the newest event from the back of the buffer
+   function Pop_Last (Buffer : in out Event_Buffer_t; Event : out Input_Event_t) return Boolean_t is
+   begin
+      --  Check if buffer is empty
+      if Buffer.Events.Is_Empty then
+         return False;
+      end if;
+
+      --  Get the last (newest) event
+      Event := Buffer.Events.Last_Element;
+
+      --  Remove it from the front
+      Buffer.Events.Delete_Last;
+
+      return True;
+   end Pop_Last;
+
    --  Protected object implementation
    protected body Protected_Input_Buffer_t is
 
@@ -46,6 +63,17 @@ package body Input_Handling is
             Event := (Char_Value => Character_t'Val (0), Modifier => None, Cmd => None);
          end if;
       end Consume;
+
+      --  Remove the most recent event from the buffer (called by input reader)
+      procedure Remove_Last (Event : out Input_Event_t) is
+         Success : Boolean_t;
+      begin
+         Success := Pop_Last (Events, Event);
+         if not Success then
+            --  Use NUL character to indicate no input (not space!)
+            Event := (Char_Value => Character_t'Val (0), Modifier => None, Cmd => None);
+         end if;
+      end Remove_Last;
 
    end Protected_Input_Buffer_t;
 
@@ -81,6 +109,14 @@ package body Input_Handling is
       ASCII_LF  : constant Character_t := Character_t'Val (10);
       ASCII_CR  : constant Character_t := Character_t'Val (13);
       ASCII_ESC : constant Character_t := Character_t'Val (27);
+
+      ARROW_PREFIX      : constant Character_t := Character_t'('[');
+      ARROW_UP          : constant Character_t := Character_t'('A');
+      ARROW_DOWN        : constant Character_t := Character_t'('B');
+      ARROW_RIGHT       : constant Character_t := Character_t'('C');
+      ARROW_LEFT        : constant Character_t := Character_t'('D');
+      Last_Event        : Input_Event_t;
+      Second_Last_Event : Input_Event_t;
 
       Pos : constant Natural_t := Character_t'Pos (C);
    begin
@@ -119,6 +155,41 @@ package body Input_Handling is
          when ASCII_ESC =>
             --  Single ESC quits immediately.
             Cmd := Quit;
+
+         when ARROW_UP .. ARROW_LEFT =>
+            --  Check the last two inputs to see if this is an arrow or not.
+            Input_Buffer.Remove_Last (Last_Event);
+            Input_Buffer.Remove_Last (Second_Last_Event);
+            if Last_Event.Cmd = None and Last_Event.Char_Value = ARROW_PREFIX
+              and Second_Last_Event.Cmd = Quit then
+               --  It was an arrow, switch to the correct arrow direction
+               case C is
+                  when ARROW_UP =>
+                     Cmd := Up;
+
+                  when ARROW_DOWN =>
+                     Cmd := Down;
+
+                  when ARROW_RIGHT =>
+                     Cmd := Right;
+
+                  when ARROW_LEFT =>
+                     Cmd := Left;
+
+                  when others =>
+                     null;
+               end case;
+            else
+               --  Not an arrow, resend the last two events if they exist
+               if Second_Last_Event.Cmd /= None
+                 or Second_Last_Event.Char_Value /= Character_t'Val (0) then
+                  Input_Buffer.Produce (Second_Last_Event);
+               end if;
+               if Last_Event.Cmd /= None
+                 or Last_Event.Char_Value /= Character_t'Val (0) then
+                  Input_Buffer.Produce (Last_Event);
+               end if;
+            end if;
 
          when others =>
             null;  --  Cmd stays None; Has_Command is True.

--- a/src/input_handling.ads
+++ b/src/input_handling.ads
@@ -8,7 +8,7 @@ package Input_Handling is
    subtype Natural_t is Natural;
 
    --  Command types that can be generated from input
-   type Command_t is (Tab, Quit, Enter, None);
+   type Command_t is (Tab, Quit, Enter, Up, Down, Right, Left, None);
 
    --  Modifier keys that can accompany a character.
    --  None   : no modifier held (ordinary keypress)
@@ -55,6 +55,10 @@ package Input_Handling is
    --  Returns True if an event was available, False if buffer was empty
    function Dequeue (Buffer : in out Event_Buffer_t; Event : out Input_Event_t) return Boolean_t;
 
+   --  Remove and return the newest event from the back of the buffer
+   --  Returns True if an event was available, False if buffer was empty
+   function Pop_Last (Buffer : in out Event_Buffer_t; Event : out Input_Event_t) return Boolean_t;
+
    --  Protected object for thread-safe input buffer access
    protected type Protected_Input_Buffer_t is
       --  Add an input event to the buffer
@@ -62,6 +66,9 @@ package Input_Handling is
 
       --  Get the next input event from the buffer
       procedure Consume (Event : out Input_Event_t);
+
+      --  Remove the most recent event from the buffer
+      procedure Remove_Last (Event : out Input_Event_t);
 
    private
       Events : Event_Buffer_t;


### PR DESCRIPTION
Adds handling for arrow keys on Linux, preventing them from accidentally prompting the quit command. Also adds support for arrow keys to thuja_demo, for navigating the text editor and displaying on the keyboard tab.